### PR TITLE
Compile mozjpeg in postinstall.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 'use strict';
 
-var BinBuild = require('bin-build');
 var BinWrapper = require('bin-wrapper');
-var chalk = require('chalk');
-var fs = require('fs');
 var path = require('path');
 
 /**
@@ -15,30 +12,8 @@ var bin = new BinWrapper ({ global: false })
     .use('jpegtran');
 
 /**
- * Only run check if binary doesn't already exist
- */
-
-fs.exists(bin.use(), function (exists) {
-    if (!exists) {
-        var builder = new BinBuild()
-            .src('https://github.com/mozilla/mozjpeg/archive/v1.0.1.tar.gz')
-            .cfg('autoreconf -fiv && ./configure --prefix="' + bin.dest() + '" --bindir="' + bin.dest() + '" --libdir="' + bin.dest() + '"')
-            .make('make && make install');
-
-        console.log('building mozjpeg');
-
-        return builder.build(function (err) {
-            if (err) {
-                return console.log(chalk.red('✗ ' + err));
-            }
-
-            console.log(chalk.green('✓ mozjpeg built successfully'));
-        });
-    }
-});
-
-/**
  * Module exports
  */
 
+module.exports = bin;
 module.exports.path = bin.use();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozjpeg",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "mozjpeg wrapper that makes it seamlessly available as a local dependency",
   "license": "MIT",
   "repository": "kevva/mozjpeg",
@@ -16,12 +16,13 @@
     "mozjpeg": "cli.js"
   },
   "scripts": {
-    "postinstall": "node index.js",
+    "postinstall": "node postinstall.js",
     "test": "mocha --reporter list --timeout 0"
   },
   "files": [
     "cli.js",
-    "index.js"
+    "index.js",
+    "postinstall.js"
   ],
   "keywords": [
     "jpeg",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var BinBuild = require('bin-build');
+var chalk = require('chalk');
+var mozjpeg = require('./index.js');
+
+var builder = new BinBuild()
+    .src('https://github.com/mozilla/mozjpeg/archive/v1.0.1.tar.gz')
+    .cfg('autoreconf -fiv && ./configure --prefix="' + mozjpeg.dest()
+         + '" --bindir="' + mozjpeg.dest() + '" --libdir="' + mozjpeg.dest()
+         + '"')
+    .make('make install');
+
+console.log("Building mozjpeg...");
+
+return builder.build(function (err) {
+    if (err) {
+        console.log(chalk.red('✗ ' + err));
+        process.exit(1);
+    }
+
+    console.log(chalk.green('✓ mozjpeg built successfully'));
+    process.exit(0);
+});


### PR DESCRIPTION
I changed the code to compile mozjpeg only once in postinstall and fail if there is a compilation error.

Until now the module was installed even if an error occurred. After that, requiring node-mozjpeg would cause a new compilation attempt (blocking the program) and a high probability of a new failure.

So, I think having an error during installation is better ;)
