### PR TITLE
Fix compilation with BSD make

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -21,8 +21,8 @@ bin.run(['-version'], err => {
 			.src('https://github.com/mozilla/mozjpeg/releases/download/v3.1/mozjpeg-3.1-release-source.tar.gz')
 			.cmd('autoreconf -fiv')
 			.cmd(cfg)
-			.cmd(`make --jobs=${cpuNum}`)
-			.cmd(`make install --jobs=${cpuNum}`);
+			.cmd(`make -j${cpuNum}`)
+			.cmd(`make install -j${cpuNum}`);
 
 		return builder.run(err => {
 			if (err) {


### PR DESCRIPTION
There's no `--jobs` in BSD make, only `-j`.

---

Closes #32 