### PR TITLE
Fix TypeError in install when no CPU info available

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -6,7 +6,6 @@ const bin = require('.');
 
 const cpuNum = (typeof os.cpus() !== 'undefined') ? os.cpus().length : 1; // Assume at least 1 CPU
 
-
 bin.run(['-version'], err => {
 	if (err) {
 		log.warn(err.message);

--- a/lib/install.js
+++ b/lib/install.js
@@ -4,15 +4,7 @@ const BinBuild = require('bin-build');
 const log = require('logalot');
 const bin = require('.');
 
-const cpus = os.cpus();
-
-if(!typeof cpus === 'undefined') {
-	const cpuNum = os.cpus().length;
-}
-else {
-	// We assume at least 1 CPU
-	const cpuNum = 1;
-}
+const cpuNum = (typeof os.cpus() !== 'undefined') ? os.cpus().length : 1; // Assume at least 1 CPU
 
 
 bin.run(['-version'], err => {

--- a/lib/install.js
+++ b/lib/install.js
@@ -4,7 +4,16 @@ const BinBuild = require('bin-build');
 const log = require('logalot');
 const bin = require('.');
 
-const cpuNum = os.cpus().length;
+const cpus = os.cpus();
+
+if(!typeof cpus === 'undefined') {
+	const cpuNum = os.cpus().length;
+}
+else {
+	// We assume at least 1 CPU
+	const cpuNum = 1;
+}
+
 
 bin.run(['-version'], err => {
 	if (err) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -4,7 +4,7 @@ const BinBuild = require('bin-build');
 const log = require('logalot');
 const bin = require('.');
 
-const cpuNum = (typeof os.cpus() !== 'undefined') ? os.cpus().length : 1; // Assume at least 1 CPU
+const cpuNum = (typeof os.cpus() === 'undefined') ? 1 : os.cpus().length;
 
 bin.run(['-version'], err => {
 	if (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,15 @@ const BinBuild = require('bin-build');
 const compareSize = require('compare-size');
 const mozjpeg = require('..');
 
-const cpuNum = os.cpus().length;
+const cpus = os.cpus();
+
+if(!typeof cpus === 'undefined') {
+	const cpuNum = os.cpus().length;
+}
+else {
+	// We assume at least 1 CPU
+	const cpuNum = 1;
+}
 
 test.cb('rebuild the mozjpeg binaries', t => {
 	const tmp = tempy.directory();

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ const BinBuild = require('bin-build');
 const compareSize = require('compare-size');
 const mozjpeg = require('..');
 
-const cpuNum = (typeof os.cpus() !== 'undefined') ? os.cpus().length : 1; // Assume at least 1 CPU
+const cpuNum = (typeof os.cpus() === 'undefined') ? 1 : os.cpus().length;
 
 test.cb('rebuild the mozjpeg binaries', t => {
 	const tmp = tempy.directory();

--- a/test/test.js
+++ b/test/test.js
@@ -10,15 +10,7 @@ const BinBuild = require('bin-build');
 const compareSize = require('compare-size');
 const mozjpeg = require('..');
 
-const cpus = os.cpus();
-
-if(!typeof cpus === 'undefined') {
-	const cpuNum = os.cpus().length;
-}
-else {
-	// We assume at least 1 CPU
-	const cpuNum = 1;
-}
+const cpuNum = (typeof os.cpus() !== 'undefined') ? os.cpus().length : 1; // Assume at least 1 CPU
 
 test.cb('rebuild the mozjpeg binaries', t => {
 	const tmp = tempy.directory();


### PR DESCRIPTION
Hi, I'm using mozjpeg-bin in a jailed ssh env (JailKit) and no CPU info is available.

This fix allows installing the package even if no CPU detected and avoid TypeError.

```
$ npm install imagemin/mozjpeg-bin

> mozjpeg@4.1.2 postinstall /web/node_modules/mozjpeg
> node lib/install.js

/web/node_modules/mozjpeg/lib/install.js:7
const cpuNum = os.cpus().length;
                        ^

TypeError: Cannot read property 'length' of undefined
    at Object.<anonymous> (/web/node_modules/mozjpeg/lib/install.js:7:25)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:442:10)
    at startup (node.js:136:18)
    at node.js:966:3
```