### PR TITLE
Enable building static binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 os:
-  #- linux
+  - linux
   - osx
 osx_image: xcode8
 node_js:
+  - 'node' # latest
   - '8'
   - '6'
   - '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 osx_image: xcode8
 node_js:
-  - 'node' # latest
+  - '10'
   - '8'
   - '6'
   - '4'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:8-slim
+
+RUN apt-get update \
+    && apt-get install autoconf libtool nasm libpng-dev automake pkg-config build-essential wget \
+    -yq --no-install-suggests --no-install-recommends --force-yes
+
+WORKDIR /src
+RUN wget --no-check-certificate https://github.com/mozilla/mozjpeg/releases/download/v3.2/mozjpeg-3.2-release-source.tar.gz
+RUN tar -xzvf mozjpeg-3.2-release-source.tar.gz
+WORKDIR /src/mozjpeg
+
+RUN autoreconf -fiv \
+    && ./configure LDFLAGS=-static libpng_LIBS='/usr/lib/x86_64-linux-gnu/libpng12.a -lz' --enable-static --disable-shared \
+    && make -j8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,9 @@ RUN apt-get update \
     -yq --no-install-suggests --no-install-recommends --force-yes
 
 WORKDIR /src
-RUN wget --no-check-certificate https://github.com/mozilla/mozjpeg/releases/download/v3.2/mozjpeg-3.2-release-source.tar.gz
-RUN tar -xzvf mozjpeg-3.2-release-source.tar.gz
-WORKDIR /src/mozjpeg
+RUN wget --no-check-certificate https://github.com/mozilla/mozjpeg/archive/v3.3.1.tar.gz -O mozjpeg-3.3.1.tar.gz
+RUN tar -xzvf mozjpeg-3.3.1.tar.gz
+WORKDIR /src/mozjpeg-3.3.1
 
 RUN autoreconf -fiv \
     && ./configure LDFLAGS=-static libpng_LIBS='/usr/lib/x86_64-linux-gnu/libpng12.a -lz' --enable-static --disable-shared \

--- a/lib/install.js
+++ b/lib/install.js
@@ -18,7 +18,7 @@ bin.run(['-version'], err => {
 		}
 
 		const cfg = [
-			`./configure --disable-shared --disable-dependency-tracking --with-jpeg8 ${cfgExtras}`,
+			`./configure --enable-static --disable-shared --disable-dependency-tracking --with-jpeg8 ${cfgExtras}`,
 			`--prefix="${bin.dest()}" --bindir="${bin.dest()}" --libdir="${bin.dest()}"`
 		].join(' ');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozjpeg",
-  "version": "5.0.0",
+  "version": "5.0.1-rc0",
   "description": "mozjpeg wrapper that makes it seamlessly available as a local dependency",
   "license": "MIT",
   "repository": "imagemin/mozjpeg-bin",
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "postinstall": "node lib/install.js",
-    "test": "xo && ava"
+    "test": "xo && ava",
+    "build-linux": "docker build -t imagemin/mozjpeg docker; docker run --rm -v $(pwd)/vendor/linux:/src/out imagemin/mozjpeg cp cjpeg /src/out"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mozjpeg",
-  "version": "5.0.1-rc0",
+  "version": "5.0.0",
   "description": "mozjpeg wrapper that makes it seamlessly available as a local dependency",
   "license": "MIT",
   "repository": "imagemin/mozjpeg-bin",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "postinstall": "node lib/install.js",
     "test": "xo && ava",
-    "build-linux": "docker build -t imagemin/mozjpeg docker; docker run --rm -v $(pwd)/vendor/linux:/src/out imagemin/mozjpeg cp cjpeg /src/out"
+    "build-linux": "docker build --tag imagemin/mozjpeg docker && docker run --rm --volume $(pwd)/vendor/linux:/src/out imagemin/mozjpeg cp cjpeg /src/out"
   },
   "files": [
     "index.js",

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ const cpuNum = os.cpus().length;
 test.cb('rebuild the mozjpeg binaries', t => {
 	const tmp = tempy.directory();
 	const cfg = [
-		'./configure --disable-shared --disable-dependency-tracking --with-jpeg8',
+		'./configure --enable-static --disable-shared --disable-dependency-tracking --with-jpeg8',
 		`--prefix="${tmp}" --bindir="${tmp}" --libdir="${tmp}"`
 	].join(' ');
 


### PR DESCRIPTION
Fixes #33 (hopefully)

- [x] [Tests passed](https://travis-ci.org/tuananh/mozjpeg-bin/builds/365438436).
- [x] Binary not included. I think the author should generate and update it himself. Shouldn't let untrusted binary in PR.

- Re-enable linux on Travis.
- Enable static link
- Include a new npm script to build binary for linux locally `npm run build-linux` (docker required). Not sure how should we proceed for macOS and Windows. I think we should use CI for that.

