### PR TITLE
Add support for setting custom binary site

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,10 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v${pkg.version}/vendor/`;
+const binarySite = process.env.MOZJPEG_BINARY_SITE ||
+                    process.env.npm_config_mozjpeg_binary_site ||
+                    'https://raw.githubusercontent.com/imagemin/mozjpeg-bin';
+const url = `${binarySite}/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/cjpeg`, 'darwin')

--- a/test/test.js
+++ b/test/test.js
@@ -38,7 +38,8 @@ test('minify a JPG', async t => {
 	const src = path.join(__dirname, 'fixtures/test.jpg');
 	const dest = path.join(tmp, 'test.jpg');
 	const args = [
-		'-outfile', dest,
+		'-outfile',
+		dest,
 		src
 	];
 


### PR DESCRIPTION
Developers in China have trouble to download binary files from Github directly, this PR supports for setting custom binary site by `MOZJPEG_BINARY_SITE=https://npm.taobao.org/mirrors/mozjpeg-bin/ yarn` which will save our lives.

Thanks to [node-sass](https://github.com/sass/node-sass/blob/master/lib/extensions.js#L240) project which inspires me.