### PR TITLE
Fix check command on install script

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -6,7 +6,7 @@ const bin = require('.');
 
 const cpuNum = os.cpus().length;
 
-bin.run(['--help'])
+bin.run(['-version'])
 	.then(() => log.success('mozjpeg pre-build test passed successfully'))
 	.catch(err => {
 		log.warn(err.message);


### PR DESCRIPTION
`cjpeg --help` exit with failure, so it will cause building from source code always.