### PR TITLE
Set number of CPUs to max of value reported from api or 1

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -5,7 +5,7 @@ const binBuild = require('bin-build');
 const log = require('logalot');
 const bin = require('.');
 
-const cpuNumber = os.cpus().length;
+const cpuNumber = Math.max(os.cpus().length,1);
 
 bin.run(['-version']).then(() => {
 	log.success('mozjpeg pre-build test passed successfully');

--- a/lib/install.js
+++ b/lib/install.js
@@ -5,7 +5,7 @@ const binBuild = require('bin-build');
 const log = require('logalot');
 const bin = require('.');
 
-const cpuNumber = Math.max(os.cpus().length,1);
+const cpuNumber = Math.max(os.cpus().length, 1);
 
 bin.run(['-version']).then(() => {
 	log.success('mozjpeg pre-build test passed successfully');


### PR DESCRIPTION
Android does not support the os.cpus api and this will result
in a value of -j=0 when executing make when compiling the native
library.
