### PR TITLE
Switch Linux-build Debian version to Debian 10 (current stable)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8-slim
+FROM debian:10-slim
 
 RUN apt-get update \
     && apt-get install autoconf libtool nasm libpng-dev automake pkg-config build-essential wget \
@@ -10,5 +10,5 @@ RUN tar -xzvf mozjpeg-3.3.1.tar.gz
 WORKDIR /src/mozjpeg-3.3.1
 
 RUN autoreconf -fiv \
-    && ./configure LDFLAGS=-static libpng_LIBS='/usr/lib/x86_64-linux-gnu/libpng12.a -lz' --enable-static --disable-shared \
+    && ./configure LDFLAGS=-static libpng_LIBS='/usr/lib/x86_64-linux-gnu/libpng16.a -lz' --enable-static --disable-shared \
     && make -j8


### PR DESCRIPTION
As Debian 8 (Jessie) became oldstable a long time ago, so I would like to upgrade the build base image to the current Debian stable image.

I tested this change locally and after rebuild and replace the cjpeg binary old commands depended on imagemin-mozjpeg are working with newer Debian versions with default libpng16 (so no need to install libpng12 package from old repositories)