### PR TITLE
Feat/allow-override-url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,8 @@ const path = require('path');
 const BinWrapper = require('bin-wrapper');
 const pkg = require('../package.json');
 
-const url = `https://raw.githubusercontent.com/imagemin/mozjpeg-bin/v${pkg.version}/vendor/`;
+const GITHUB_RAW_URL = process.env.GITHUB_RAW_URL ? process.env.GITHUB_RAW_URL : 'https://raw.githubusercontent.com/imagemin/mozjpeg-bin/'
+const url = `${GITHUB_RAW_URL}/imagemin/mozjpeg-bin/v${pkg.version}/vendor/`;
 
 module.exports = new BinWrapper()
 	.src(`${url}macos/cjpeg`, 'darwin')

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,11 @@ You probably want [`imagemin-mozjpeg`](https://github.com/imagemin/imagemin-mozj
 $ npm install mozjpeg
 ```
 
+This package attempts to download a prebuilt binary on post install.
+This attempts to reach out to `raw.githubusercontent.com`. If you would rather pull this from an
+internal proxy, you can set `GITHUB_RAW_URL` on your environment to overwrite the url to your 
+internal proxy.
+
 
 ## Usage
 


### PR DESCRIPTION
This allows users to pull prebuilt binaries through their own proxy endpoints
instead of hitting raw.githubusercontent.com